### PR TITLE
chore: Add LayerFeaturesCount interface oc:5097

### DIFF
--- a/src/feature.ts
+++ b/src/feature.ts
@@ -75,9 +75,9 @@ export interface responseDeleteMedia {
   success: 'media deleted';
 }
 
-export interface LayerFeaturesCount {
-  [layerId: string]: {
-    tracks: number;
-    pois: number;
-  };
+export interface LayerFeatureCount {
+  tracks: number;
+  pois: number;
 }
+export type LayerId = string;
+export type LayerFeaturesCount = Record<LayerId, LayerFeatureCount>;

--- a/src/feature.ts
+++ b/src/feature.ts
@@ -74,3 +74,10 @@ export interface WmProperties {
 export interface responseDeleteMedia {
   success: 'media deleted';
 }
+
+export interface LayerFeaturesCount {
+  [layerId: string]: {
+    tracks: number;
+    pois: number;
+  };
+}


### PR DESCRIPTION
This commit adds the LayerFeaturesCount interface to the codebase. It includes properties for tracking the number of tracks and points of interest (pois) in each layer.
