### PR TITLE
chore: add new types for home result tab oc: 6780

### DIFF
--- a/src/home-result-tab.ts
+++ b/src/home-result-tab.ts
@@ -1,0 +1,11 @@
+/**
+ * Type for result tab selection in home component
+ * Can be 'tracks', 'pois', or null if no results available
+ */
+export type HomeResultTab = 'tracks' | 'pois' | null;
+
+/**
+ * Type for filter type (always has a value, never null)
+ */
+export type FilterType = 'tracks' | 'pois';
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,4 +3,4 @@ export * from './slope-chart';
 export * from './environment';
 export * from './language';
 export * from './privacy-agree';
-export * from './home-result-tab';
+export * from './user-activity';

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,4 @@ export * from './slope-chart';
 export * from './environment';
 export * from './language';
 export * from './privacy-agree';
+export * from './home-result-tab';

--- a/src/user-activity.ts
+++ b/src/user-activity.ts
@@ -7,5 +7,4 @@ export type HomeResultTab = 'tracks' | 'pois' | null;
 /**
  * Type for filter type (always has a value, never null)
  */
-export type FilterType = 'tracks' | 'pois';
-
+export type FilterType = 'tracks' | 'pois' | null;


### PR DESCRIPTION
Introduces new TypeScript types for home result tab and filter. Exports the new types for external use.

Relates to oc_6780