### PR TITLE
chore(config, posthog): ✨ expand configuration interfaces and enhance Posthog client oc:7090

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -20,7 +20,6 @@ export interface APP {
   poi_acquisition_form?: any;
   track_acquisition_form?: any;
   welcome?: string;
-  posthog: boolean;
 }
 
 export interface WEBAPP {
@@ -28,5 +27,110 @@ export interface WEBAPP {
   draw_track_show: boolean;
   editing_inline_show: boolean;
   splash_screen_show: boolean;
-  posthog: boolean;
+}
+
+export interface OPTIONS {
+  addArrowsOverTracks: boolean;
+  baseUrl: string;
+  beBaseUrl?: string;
+  caiScaleStyleZoom: number;
+  clustering: CLUSTERING;
+  customBackgroundImageUrl?: string;
+  detailsMapBehaviour?: DETAILSMAPBEHAVIOUR;
+  downloadFullGemoetryRouteIndex: boolean;
+  downloadRoutesInWebapp: boolean;
+  download_track_enable?: boolean;
+  enableTrackAdoption: boolean;
+  forceDefaultFeatureColor: boolean;
+  forceWelcomePagePopup: boolean;
+  galleryAnimationType?: string;
+  hideDisclaimer: boolean;
+  hideFilters: boolean;
+  hideGlobalMap: boolean;
+  hideNewsletterInSignup: boolean;
+  hideSearch: boolean;
+  highlightMapButton: boolean;
+  highlightReadMoreButton: boolean;
+  mapAttributions?: MAPATTRIBUTION[];
+  maxFitZoom?: number;
+  maxZoomFeaturesInViewport?: number;
+  minDynamicOverlayLayersZoom: number;
+  minZoomFeaturesInViewport?: number;
+  passwordRecoveryUrl: string;
+  poiIconRadius: number;
+  poiIconZoom: number;
+  poiLabelMinZoom: number;
+  poiMaxRadius: number;
+  poiMinRadius: number;
+  poiMinZoom: number;
+  poiSelectedRadius: number;
+  print_track_enable?: boolean;
+  privacyUrl: string;
+  resetFiltersAtStartup: boolean;
+  showAppDownloadButtons: APPDOWNLOADBUTTONS;
+  showAscent: boolean;
+  showDescent: boolean;
+  showDifficultyLegend: boolean;
+  showDistance: boolean;
+  showDownloadTiles: boolean;
+  showDurationBackward: boolean;
+  showDurationForward: boolean;
+  showEditLink: boolean;
+  showEleFrom: boolean;
+  showEleMax: boolean;
+  showEleMin: boolean;
+  showEleTo: boolean;
+  showEmbeddedHtml: boolean;
+  showFeaturesInViewport: boolean;
+  showGeojsonDownload: boolean;
+  showGetDirections?: boolean;
+  showGpxDownload: boolean;
+  showHelp: boolean;
+  showKmlDownload: boolean;
+  showMapViewfinder: boolean;
+  showMediaName: boolean;
+  showPoiListOffline: boolean;
+  showShapefileDownload: boolean;
+  showTrackRefLabel: boolean;
+  showTravelMode?: boolean;
+  show_searchbar?: boolean;
+  skipRouteIndexDownload: boolean;
+  startFiltersDisabled: boolean;
+  startUrl: string;
+  termsAndConditionsUrl?: string;
+  trackAdoptionUrl?: string;
+  trackReconnaissanceUrl?: string;
+  trackRefLabelZoom: number;
+  useCaiScaleStyle: boolean;
+  useFeatureClassicSelectionStyle: boolean;
+  voucherUrl?: string;
+  analytics: Analytics;
+}
+
+export interface CLUSTERING {
+  enable: boolean;
+  highZoom?: number;
+  highZoomRadius: number;
+  radius: number;
+}
+
+export type DETAILSMAPBEHAVIOUR = 'all' | 'track' | 'poi' | 'route';
+
+export interface MAPATTRIBUTION {
+  label?: string;
+  url?: string;
+}
+
+export interface APPDOWNLOADBUTTONS {
+  all: boolean;
+  poi: boolean;
+  route: boolean;
+  track: boolean;
+}
+
+export interface Analytics {
+  appEnabled: boolean;
+  webappEnabled: boolean;
+  mobileEnabled: boolean;
+  recordingProbability: number;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,6 +20,7 @@ export interface APP {
   poi_acquisition_form?: any;
   track_acquisition_form?: any;
   welcome?: string;
+  analytics: Analytics;
 }
 
 export interface WEBAPP {
@@ -27,6 +28,7 @@ export interface WEBAPP {
   draw_track_show: boolean;
   editing_inline_show: boolean;
   splash_screen_show: boolean;
+  analytics: Analytics;
 }
 
 export interface OPTIONS {
@@ -104,7 +106,6 @@ export interface OPTIONS {
   useCaiScaleStyle: boolean;
   useFeatureClassicSelectionStyle: boolean;
   voucherUrl?: string;
-  analytics: Analytics;
 }
 
 export interface CLUSTERING {
@@ -129,8 +130,7 @@ export interface APPDOWNLOADBUTTONS {
 }
 
 export interface Analytics {
-  appEnabled: boolean;
-  webappEnabled: boolean;
-  mobileEnabled: boolean;
-  recordingProbability: number;
+  enabled: boolean;
+  recordingEnabled: boolean;
+  recordingProbability?: number;
 }

--- a/src/posthog.ts
+++ b/src/posthog.ts
@@ -2,14 +2,19 @@
  * Interfaccia UNICA usata dal tuo codice (posthog-js like)
  * - capture(event, props)
  * - identify(id, props)
- * - initAndRegister(props) - inizializza e registra le proprietà in un'unica chiamata
+ * - initAndRegister(props, options) - inizializza e registra le proprietà in un'unica chiamata
  * - reset()
  */
 export interface WmPosthogClient {
   capture(event: string, props?: WmPosthogProps): void | Promise<void>;
   identify(distinctId: string, props?: WmPosthogProps): void | Promise<void>;
-  initAndRegister(props: WmPosthogProps, enabled?: boolean): void | Promise<void>;
+  initAndRegister(props: WmPosthogProps, options?: WmPosthogInitOptions): void | Promise<void>;
   reset(): void | Promise<void>;
+}
+
+export interface WmPosthogInitOptions {
+  enabled?: boolean;
+  recordingProbability?: number; // 0-1, probabilità di registrazione video (es. 0.5 = 50%)
 }
 
 export interface WmPosthogConfig {

--- a/src/posthog.ts
+++ b/src/posthog.ts
@@ -1,3 +1,5 @@
+import {Analytics} from './config';
+
 /**
  * Interfaccia UNICA usata dal tuo codice (posthog-js like)
  * - capture(event, props)
@@ -12,10 +14,7 @@ export interface WmPosthogClient {
   reset(): void | Promise<void>;
 }
 
-export interface WmPosthogInitOptions {
-  enabled?: boolean;
-  recordingProbability?: number; // 0-1, probabilità di registrazione video (es. 0.5 = 50%)
-}
+export type WmPosthogInitOptions = Partial<Analytics>;
 
 export interface WmPosthogConfig {
   apiKey: string;


### PR DESCRIPTION
- Removed `posthog` boolean from `APP` and `WEBAPP` interfaces.
- Introduced new `OPTIONS`, `CLUSTERING`, `DETAILSMAPBEHAVIOUR`, `MAPATTRIBUTION`, `APPDOWNLOADBUTTONS`, and `Analytics` interfaces for comprehensive configuration.
- Updated `initAndRegister` method in `WmPosthogClient` interface to accept an `options` parameter for improved initialization control.
