### PR TITLE
feat: add redirect for maps.valdicecinaoutdoor.it oc:8039

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,34 @@
+# CLAUDE.md — wm-types
+
+## Stack
+
+- Tipi TypeScript condivisi tra `wm-core`, `map-core` e `wm-webapp`
+- Nessuna logica applicativa — solo interfacce, tipi e costanti
+
+## Architettura
+
+`wm-types` è il livello base della catena di dipendenze: `wm-types` → `wm-core` → `wm-webapp`.
+
+Il file principale è `src/environment.ts`, che contiene:
+- Tipo `Environment` e interfacce correlate (`Shard`, `Redirect`, `ShardName`)
+- Costante `shards` — mappa dei backend per ogni shard (geohub, maphub, osm2cai, ecc.)
+- Costante `redirects` — mappa domini custom → `{shardName, appId}`
+
+### Meccanismo redirects
+
+Quando la webapp viene caricata da un dominio presente in `redirects`, usa automaticamente l'`appId` e lo `shardName` specificati anziché quelli di default. Il matching avviene tramite `hostname.includes(key)` (sottostringa).
+
+**Per aggiungere un nuovo dominio custom:** aggiungere una entry all'oggetto `redirects` in `src/environment.ts`, poi allineare il submodule in `wm-webapp`.
+
+## Feature disponibili
+
+| Feature | Ticket | Moduli toccati | Note |
+|---|---|---|---|
+| Redirect maps.valdicecinaoutdoor.it | oc:8039 | `src/environment.ts` | appId 64, shard geohub |
+
+## Decisioni architetturali
+
+### Redirect maps.valdicecinaoutdoor.it (oc:8039)
+- La modifica riguarda solo `redirects` in `src/environment.ts` — virtualhost e deploy sono task separati.
+- Il matching usa `hostname.includes()`: subdomain come `www.maps.valdicecinaoutdoor.it` matchano automaticamente (non è un problema se il DNS per `www.` non è configurato).
+- Il redirect deve essere deployato prima che il virtualhost punti alla nuova webapp: in caso contrario l'app riceve `NaN` come `appId`.

--- a/docs/features/8039-aggiornare-web-app-maps-valdicecinaoutdoor-it/notes.md
+++ b/docs/features/8039-aggiornare-web-app-maps-valdicecinaoutdoor-it/notes.md
@@ -1,0 +1,20 @@
+> Ticket: oc:8039
+
+# Notes — Aggiornare web app maps.valdicecinaoutdoor.it
+
+## Deviazioni dal piano
+Nessuna.
+
+## Bug trovati
+Nessuno.
+
+## Decisioni
+- Scope ridotto rispetto al titolo del ticket: virtualhost e deploy sono task separati. La modifica di codice è solo l'aggiunta del redirect in `wm-types`.
+- L'allineamento del submodule in `wm-webapp` è gestito manualmente dal developer.
+
+## Follow-up
+- Allineamento submodule `wm-types` in `wm-webapp` dopo il commit (⚠️ deve avvenire prima dell'aggiornamento del virtualhost).
+- Verificare che appId 64 su geohub sia configurato e pronto prima del go-live.
+- Il meccanismo `redirects` usa `hostname.includes()` (sottostringa): `www.maps.valdicecinaoutdoor.it` matcherebbe automaticamente il redirect, ma non è un problema se il DNS per `www.` non è configurato.
+- Cache PWA/Service Worker: utenti con vecchia webapp in cache potrebbero non vedere la nuova immediatamente dopo il go-live. Valutare un cache busting al momento del deploy.
+- Non esistono test che coprano il meccanismo `redirects` per questo dominio. Da considerare in un ciclo successivo.

--- a/docs/features/8039-aggiornare-web-app-maps-valdicecinaoutdoor-it/overview.md
+++ b/docs/features/8039-aggiornare-web-app-maps-valdicecinaoutdoor-it/overview.md
@@ -1,0 +1,24 @@
+> Ticket: oc:8039
+
+# Aggiornare web app maps.valdicecinaoutdoor.it
+
+## Cosa cambia
+Viene aggiunta una entry nell'oggetto `redirects` di `src/environment.ts` in modo che, quando la webapp viene caricata dal dominio `maps.valdicecinaoutdoor.it`, utilizzi automaticamente l'`appId` 64 sullo shard `geohub`.
+
+## Perché
+Il sito `maps.valdicecinaoutdoor.it` punta attualmente alla vecchia webapp. Per servire la nuova web app Angular/Ionic su quel dominio, l'app deve riconoscere l'hostname e caricare la configurazione corretta (appId 64, shard geohub).
+
+## Requisiti
+- [ ] Aggiungere `'maps.valdicecinaoutdoor.it': { shardName: 'geohub', appId: 64 }` all'oggetto `redirects` in `src/environment.ts`
+
+## Rischi
+- Nessun rischio architetturale: il meccanismo `redirects` è già consolidato e usato da altri domini analoghi.
+
+## Out of scope
+- Aggiornamento del virtualhost sul server (task separato)
+- Deploy della nuova webapp su `maps.valdicecinaoutdoor.it` (task separato)
+- Variante `www.maps.valdicecinaoutdoor.it` (non richiesta)
+- Commit e allineamento del submodule in wm-webapp (gestiti manualmente dal developer)
+
+## Moduli toccati
+- `src/environment.ts` — aggiunta entry in `redirects`

--- a/docs/features/8039-aggiornare-web-app-maps-valdicecinaoutdoor-it/plan.md
+++ b/docs/features/8039-aggiornare-web-app-maps-valdicecinaoutdoor-it/plan.md
@@ -1,0 +1,64 @@
+> Ticket: oc:8039
+
+# Plan — Aggiornare web app maps.valdicecinaoutdoor.it
+
+## Repo coinvolto
+`wm-types` (`src/app/shared/wm-types`) — unica modifica di codice.
+
+---
+
+## Step 1 — Aggiungere il redirect in `src/environment.ts`
+
+**File:** `src/environment.ts`
+**Riga:** dopo l'ultima entry dell'oggetto `redirects` (attualmente `maps.sentierodeiducati.it` a riga ~199), prima della chiusura `};`
+
+Aggiungere:
+
+```typescript
+'maps.valdicecinaoutdoor.it': {
+  shardName: 'geohub',
+  appId: 64,
+},
+```
+
+Risultato atteso:
+
+```typescript
+  'maps.sentierodeiducati.it': {
+    shardName: 'geohub',
+    appId: 60,
+  },
+  'maps.valdicecinaoutdoor.it': {
+    shardName: 'geohub',
+    appId: 64,
+  },
+};
+```
+
+**Commit convention (a cura del developer):**
+```
+feat(oc:8039): add redirect for maps.valdicecinaoutdoor.it
+```
+
+---
+
+## Step 2 — Allineamento submodule in wm-webapp (a cura del developer)
+
+Dopo il commit in `wm-types`, aggiornare il puntatore SHA del submodule in `wm-webapp`:
+
+```bash
+# da wm-webapp/
+cd src/app/shared/wm-types
+git pull origin <branch>
+cd ../../..
+git add src/app/shared/wm-types
+git commit -m "chore(oc:8039): align wm-types submodule"
+```
+
+> ⚠️ Se questo step viene omesso, il build di wm-webapp userà il vecchio SHA e il redirect non sarà presente.
+
+---
+
+## Note di sequenza
+
+- Il redirect nel codice deve essere deployato **prima** che il virtualhost di `maps.valdicecinaoutdoor.it` punti alla nuova webapp. Se il virtualhost viene aggiornato prima del deploy, l'app riceve `NaN` come `appId` e va in errore.

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -200,4 +200,8 @@ export const redirects: Redirects = {
     shardName: 'geohub',
     appId: 60,
   },
+  'maps.valdicecinaoutdoor.it': {
+    shardName: 'geohub',
+    appId: 64,
+  },
 };


### PR DESCRIPTION
Adds `maps.valdicecinaoutdoor.it` to the redirects to serve the new Angular/Ionic web app with `appId` 64 on the `geohub` shard. This allows the web app to automatically configure itself for the correct domain and app settings.