### PR TITLE
feat(oc:8127): add mode field to WmPosthogProps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Quando la webapp viene caricata da un dominio presente in `redirects`, usa autom
 
 | Feature | Ticket | Moduli toccati | Note |
 |---|---|---|---|
-| Campo `mode` in WmPosthogProps | oc:8127 | `src/posthog.ts` | Usato dal heartbeat `userOnline` in wm-core |
+| GeolocationMode + mode in WmPosthogProps | oc:8127 | `src/user-activity.ts`, `src/posthog.ts` | Tipo `GeolocationMode` condiviso tra GeolocationService e WmPosthogProps |
 | Redirect maps.valdicecinaoutdoor.it | oc:8039 | `src/environment.ts` | appId 64, shard geohub |
 
 ## Decisioni architetturali

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ Quando la webapp viene caricata da un dominio presente in `redirects`, usa autom
 
 | Feature | Ticket | Moduli toccati | Note |
 |---|---|---|---|
+| Campo `mode` in WmPosthogProps | oc:8127 | `src/posthog.ts` | Usato dal heartbeat `userOnline` in wm-core |
 | Redirect maps.valdicecinaoutdoor.it | oc:8039 | `src/environment.ts` | appId 64, shard geohub |
 
 ## Decisioni architetturali

--- a/src/posthog.ts
+++ b/src/posthog.ts
@@ -1,5 +1,6 @@
 import {Analytics} from './config';
 import {Location} from './feature';
+import {GeolocationMode} from './user-activity';
 
 /**
  * Interfaccia UNICA usata dal tuo codice (posthog-js like)
@@ -43,5 +44,5 @@ export interface WmPosthogProps {
   results_count?: number;
   layer_name?: string;
   layer_label?: string;
-  mode?: string;
+  mode?: GeolocationMode;
 }

--- a/src/posthog.ts
+++ b/src/posthog.ts
@@ -43,4 +43,5 @@ export interface WmPosthogProps {
   results_count?: number;
   layer_name?: string;
   layer_label?: string;
+  mode?: string;
 }

--- a/src/user-activity.ts
+++ b/src/user-activity.ts
@@ -1,3 +1,5 @@
+export type GeolocationMode = 'navigation' | 'recording' | 'stopped';
+
 /**
  * Type for result tab selection in home component
  * Can be 'tracks', 'pois', or null if no results available


### PR DESCRIPTION
## Summary

- Aggiunto campo `mode?: string` a `WmPosthogProps` in `src/posthog.ts`
- Utilizzato dal heartbeat `userOnline` implementato in `wm-core` (oc:8127)

## Test plan

- [ ] Verificare che `wm-core` e `wm-webapp` compilino senza errori TypeScript dopo il bump del submodule
- [ ] Verificare che l'evento `userOnline` riporti il campo `mode` in PostHog live events

🤖 Generated with [Claude Code](https://claude.com/claude-code)